### PR TITLE
Add the type="module" attribute to the <script> tag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
 <body>
     <div id="root"></div>
-    <script src="index.js"></script>
+    <script type="module" src="index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Necessary to add the type="module" attribute to the <script> tag.

The following error occrus: 

Parcel encountered errors
@parcel/transformer-js: Browser scripts cannot have imports or exports.
[/workspaces/satellite-tracker/index.js:1:1](https://cbdonohue-obscure-disco-r77g4g6g46cxjv4-1234.preview.app.github.dev/__parcel_launch_editor?file=%2Fworkspaces%2Fsatellite-tracker%2Findex.js%3A1%3A1)
> 1 | import * as React from "react";
>   | ^
  2 | import { render } from "react-dom";
  3 | import App from "./App";[/workspaces/satellite-tracker/index.html:9:5](https://cbdonohue-obscure-disco-r77g4g6g46cxjv4-1234.preview.app.github.dev/__parcel_launch_editor?file=%2Fworkspaces%2Fsatellite-tracker%2Findex.html%3A9%3A5)
   8 |     <div id="root"></div>
>  9 |     <script src="index.js"></script>
>    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The environment was originally created here
  10 | </body>
  11 | 
Add the type="module" attribute to the <script> tag.`